### PR TITLE
Added Windows support and fixed name

### DIFF
--- a/ansible/group_vars/tomcat-servers
+++ b/ansible/group_vars/tomcat-servers
@@ -1,6 +1,6 @@
 # Here are variables related to the Tomcat installation
 
-tomcat_url: http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.21/bin/apache-tomcat-8.0.21.tar.gz
+tomcat_url: http://www.eu.apache.org/dist/tomcat/tomcat-8/v8.0.23/bin/apache-tomcat-8.0.23.tar.gz
 maven_url: http://www.gtlib.gatech.edu/pub/apache/maven/maven-3/3.3.1/binaries/apache-maven-3.3.1-bin.tar.gz
 
 http_port: 8080
@@ -10,4 +10,3 @@ https_port: 8443
 
 admin_username: admin
 admin_password: adminsecret
-

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,2 +1,20 @@
-[tomcat-servers]
-vagrant ansible_ssh_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_user=vagrant ansible_sudo=true
+#!/usr/bin/python
+import json, sys, getopt
+conf = {'tomcat-servers': {
+    'ansible_ssh_host': '127.0.0.1',
+    'ansible_ssh_port': 22,
+#    'ansible_ssh_private_key_file': '~/.vagrant.d/insecure_private_key',
+    'ansible_ssh_user': 'vagrant',
+    'ansible_ssh_pass': 'vagrant',
+    'ansible_sudo': True
+}}
+
+def main(args):
+    if len(args) == 1 and args[0] == '--list':
+        print json.dumps(conf)
+        sys.exit()
+
+if __name__ == "__main__":
+   main(sys.argv[1:])
+
+#vagrant ansible_ssh_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key ansible_ssh_user=vagrant ansible_sudo=true

--- a/ansible/roles/dniprorada-java/tasks/main.yml
+++ b/ansible/roles/dniprorada-java/tasks/main.yml
@@ -14,18 +14,13 @@
   args:
     chdir: /project
 
-- name: Clean redis 
-  command: /usr/bin/mvn clean install 
-  args:
-    chdir: /project/redis  
-
 - name: Building workflow project
   command: /usr/bin/mvn install -DskipTests
   args:
     chdir: /project
 
 - name: copy application to webapp directory
-  command: cp /project/wf-dniprorada/target/wf-dniprorada.war /usr/share/tomcat/webapps/wf-dniprorada.war
+  command: cp /project/wf-base/target/wf-base.war /usr/share/tomcat/webapps/wf-base.war
 
 - name: Start Tomcat
   service: name=tomcat state=started enabled=yes


### PR DESCRIPTION
Для тих, хто звик до Windows, переробив hosts файл, оскільки без цього фіксу Vagrant не сприймає текстовий файл як текст, а не програму. Оскільки у зв'язці Vagrant та використаного Debian неможливо зробити "-x" цьому файлу, довелося перетворити його на невеличкий скрипт на python. (Windows 7 x64)
Також поправив мінорну версію Tomcat та wf-dniprorada на wf-base, і додав аутентифікацію за дефолтним Vagrant паролем, а не ключем.
Система успішно розгортається, якщо запускати ansible не на хості з Windows, а на самій гостьовій машині.
